### PR TITLE
Updated certify-web example

### DIFF
--- a/certify-web/README.md
+++ b/certify-web/README.md
@@ -87,3 +87,5 @@ Below, it is assumed that "bbc_core.py" runs at the user's home directory, and E
 7. Start index.py of this example
 
     By default, the server runs at "http://localhost:5000/cert". You can paste your JSON document onto the text area, or open an existing JSON file for processing.
+
+**certify_tool.py** is a utility program to print the query string for a certificate that is compatible with "certificates" example.

--- a/certify-web/api/body.py
+++ b/certify-web/api/body.py
@@ -342,21 +342,11 @@ def get_proof_for_document():
 def register_document():
     document = get_document(request)
 
-    registry = g.store.read_user(NAME_REGISTRY)
-    user = g.store.read_user(NAME_USER)
-
-    g.idPubkeyMap = id_lib.BBcIdPublickeyMap(domain_id)
-    g.registry = registry_lib.BBcRegistry(domain_id, registry.user_id,
-            registry.user_id, g.idPubkeyMap)
-
-    g.registry.register_document(user.user_id, document,
-            registry_lib.DocumentSpec(description="certificate"),
-            keypair=registry.keypair)
+    digest = hashlib.sha256(document.file()).digest()
 
     g.client = run_client()
 
-    g.client.register_in_ledger_subsystem(None,
-            g.registry.get_document_digest(document.document_id))
+    g.client.register_in_ledger_subsystem(None, digest)
     dat = wait_check_result_msg_type(g.client.callback,
             bbclib.MsgType.RESPONSE_REGISTER_HASH_IN_SUBSYS)
 

--- a/certify-web/api/body.py
+++ b/certify-web/api/body.py
@@ -149,8 +149,12 @@ def dict2xml(dic):
     root = ET.fromstring('<c/>')
     dict2xml_element(root, dic)
 
-    current_app.logger.info('JSON to XML: {0}'.format(ET.tostring(root,
-            encoding='utf-8').decode()))
+    try:
+        current_app.logger.info('JSON to XML: {0}'.format(ET.tostring(root,
+                encoding='utf-8').decode()))
+
+    except RuntimeError:
+        pass
 
     return root
 

--- a/certify-web/certify_tool.py
+++ b/certify-web/certify_tool.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2021 beyond-blockchain.org.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import argparse
+import binascii
+import hashlib
+import json
+import sys
+import urllib.parse
+import xml.etree.ElementTree as ET
+
+from api.body import dict2xml
+from bbc1.core import bbclib
+from bbc1.lib import registry_lib
+
+
+def argument_parser():
+    argparser = argparse.ArgumentParser()
+    subparsers = argparser.add_subparsers(dest="command_type", help='commands')
+
+    # options
+#    argparser.add_argument('-u', '--url_encode', action='store_true',
+#            help='print URL-encoded string')
+
+    # query command
+    parser = subparsers.add_parser('query',
+            help='Get query string')
+    parser.add_argument('json_file', action='store', default=None,
+            help='Certificate JSON file')
+
+    return argparser.parse_args()
+
+
+def print_query_string(json_file):
+    with open(json_file) as f:
+        dic = json.load(f)
+
+    root = dict2xml(dic)
+
+    proof = dic['proof']
+
+    if proof is None:
+        print('Not a certificate.')
+        return
+
+    spec = proof['spec']
+    subtree = proof['subtree']
+
+    s = ''
+    for directive in subtree:
+        s += 'r-' if directive['position'] == 'right' else 'l-'
+        s += directive['digest'] + ':'
+    s = s[:-1]
+
+    qdic = {}
+    qdic['certificate'] = ET.tostring(root, encoding='utf-8').decode('utf-8')
+    qdic['subtree'] = s
+
+    print(urllib.parse.urlencode(qdic))
+
+
+def sys_check(args):
+    return
+
+
+if __name__ == '__main__':
+
+    parsed_args = argument_parser()
+
+    try:
+        sys_check(parsed_args)
+
+    except Exception as e:
+        print(str(e))
+        sys.exit(0)
+
+    if parsed_args.command_type == 'query':
+        print_query_string(parsed_args.json_file)
+
+    sys.exit(0)
+
+
+# end of certify_tool.py


### PR DESCRIPTION
* Handles documents without id better.
* Provides a utility program to print query strings compatible with 'certificates' example.
